### PR TITLE
Add ready_for_review trigger to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,12 +4,10 @@ on:
   workflow_call:
     types: [completed]
   push:
-    branches:
-      - main
+    branches: [ main ]
   pull_request:
-    branches:
-      - main
-    types: [opened, synchronize, reopened]
+    branches: [ main ]
+    types: [ opened, synchronize, reopened, ready_for_review ]
   schedule:
     - cron: '0 0 * * *' # Runs at 12:00 UTC every day
 


### PR DESCRIPTION
### TL;DR
Updated GitHub Actions workflow trigger conditions to include `ready_for_review` event and simplified branch syntax.

### What changed?
- Added `ready_for_review` event type to pull request triggers
- Simplified branch syntax from multi-line to single-line format
- Maintained daily cron schedule at UTC 00:00

### How to test?
1. Create a draft pull request and mark it as "Ready for review"
2. Verify that the CI workflow triggers automatically
3. Confirm workflow still triggers on push to main and other PR events

### Why make this change?
To ensure CI runs when pull requests transition from draft to ready for review, providing earlier feedback on code changes. The simplified branch syntax maintains the same functionality while improving readability.