### PR TITLE
Add checkout step to scheduled GTFS workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,9 @@ jobs:
     if: github.event_name == 'schedule'
 
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
       - name: Download GTFS Data
         run: ./gradlew runKRAIL-GTFS
 


### PR DESCRIPTION
### TL;DR
Added repository checkout step to CI workflow for GTFS data download

### What changed?
Added the `actions/checkout@v4` step before the GTFS data download task in the scheduled CI workflow

### How to test?
1. Trigger the scheduled workflow
2. Verify that the GTFS data download step executes successfully
3. Confirm the workflow can access repository files after checkout

### Why make this change?
The workflow requires access to repository files to execute the Gradle task for downloading GTFS data. Without the checkout step, the workflow cannot access the necessary files and would fail.