### PR TITLE
Configure Java 21 toolchain settings

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -43,8 +43,15 @@ dependencies {
 tasks.test {
     useJUnitPlatform()
 }
+
 kotlin {
     jvmToolchain(21)
+}
+
+java {
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(JavaVersion.VERSION_21.majorVersion))
+    }
 }
 
 tasks.register<JavaExec>("runKRAIL-GTFS") {


### PR DESCRIPTION
### TL;DR
Added explicit Java 21 toolchain configuration alongside existing Kotlin toolchain settings.

### What changed?
Added a new `java` block in the Gradle build file to explicitly set the Java language version to 21, matching the existing Kotlin JVM toolchain version.

### How to test?
1. Build the project using `./gradlew build`
2. Verify that the project compiles successfully with Java 21
3. Run existing tests to ensure compatibility

### Why make this change?
Ensures consistent Java version usage across the project by explicitly declaring Java 21 requirements in the build configuration. This prevents potential version mismatches between Kotlin and Java compilations.