### PR TITLE
Add JDK setup step to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,12 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: zulu
+          java-version: 21
+
       - name: Download GTFS Data
         run: ./gradlew runKRAIL-GTFS
 


### PR DESCRIPTION
### TL;DR
Added JDK 21 setup step to CI workflow

### What changed?
Added a new step in the CI workflow to set up JDK 21 using Zulu distribution before downloading GTFS data

### How to test?
1. Check that the CI workflow runs successfully
2. Verify that the GTFS data download step executes properly after JDK setup

### Why make this change?
To ensure the CI environment has the correct Java runtime environment for executing the GTFS data download task, preventing potential runtime compatibility issues