### PR TITLE
Add CLI builder function to main process

### DIFF
--- a/src/main/kotlin/app/krail/kgtfs/Main.kt
+++ b/src/main/kotlin/app/krail/kgtfs/Main.kt
@@ -10,10 +10,15 @@ fun main() {
     runBlocking {
         NswGtfsManager.fetch(refresh = true)
         buildUIFast()
+        buildCLI()
         exitProcess(0)
     }
 }
 
 fun buildUIFast() {
     println("UI")
+}
+
+fun buildCLI() {
+    println("CLI")
 }


### PR DESCRIPTION
### TL;DR
Added CLI initialization alongside UI setup

### What changed?
- Added a new `buildCLI()` function
- Modified main function to call `buildCLI()` after UI initialization

### How to test?
1. Run the application
2. Verify that both "UI" and "CLI" messages are printed to the console
3. Confirm the application exits successfully

### Why make this change?
To support command-line interface functionality in addition to the existing UI, providing users with multiple ways to interact with the application