### PR TITLE
Reorder environment setup steps in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,10 +18,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Setup environment variables
-        run: |
-          echo "NSW_TRANSPORT_API_KEY=${{ secrets.NSW_TRANSPORT_API_KEY }}" >> $GITHUB_ENV
-
       - name: Set up JDK
         uses: actions/setup-java@v4
         with:
@@ -56,6 +52,10 @@ jobs:
         with:
           distribution: zulu
           java-version: 21
+
+      - name: Setup environment variables
+        run: |
+          echo "NSW_TRANSPORT_API_KEY=${{ secrets.NSW_TRANSPORT_API_KEY }}" >> $GITHUB_ENV
 
       - name: Download GTFS Data
         run: ./gradlew runKRAIL-GTFS


### PR DESCRIPTION
### TL;DR
Reordered GitHub Actions workflow steps to ensure environment variables are set after Java setup.

### What changed?
Moved the environment variable setup step after the Java setup in the CI workflow. The NSW Transport API key is now configured later in the workflow sequence.

### How to test?
1. Check that the GitHub Actions workflow runs successfully
2. Verify that the GTFS data download step completes without errors
3. Confirm that the NSW Transport API key is properly accessible during the workflow

### Why make this change?
To establish a more logical workflow sequence where all prerequisites (like Java setup) are completed before setting up environment-specific configurations. This ensures that the environment is fully prepared before attempting to use any environment variables.