### PR TITLE
Skip CI build for auto-generated PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     needs: setup
+    if: github.event_name != 'pull_request' || !contains(github.event.pull_request.labels.*.name, 'auto-generated')
 
     steps:
       - name: Checkout repository
@@ -107,6 +108,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           branch: ${{ env.BRANCH_NAME }}
           base: main
+          labels: auto-generated
           committer: Github Actions Bot <41898282+github-actions[bot]@users.noreply.github.com>
           author: Github Actions Bot <41898282+github-actions[bot]@users.noreply.github.com>
           commit-message: 'Add generated NSW_STOPS.json'


### PR DESCRIPTION
### TL;DR
Skip CI builds for auto-generated PRs and add auto-generated label to automated PRs

### What changed?
- Added condition to skip CI builds when PR has 'auto-generated' label
- Added 'auto-generated' label to automated PRs created by GitHub Actions

### How to test?
1. Create a PR with the 'auto-generated' label
2. Verify that CI build is skipped
3. Verify that automated PRs get labeled as 'auto-generated'

### Why make this change?
Prevents unnecessary CI builds on auto-generated content, saving compute resources and reducing pipeline execution time. This is particularly useful for PRs that contain automatically generated data files which don't require traditional CI validation.