### PR TITLE
Consolidate CI workflow steps and remove test file

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,13 +6,14 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
-    types: [opened, synchronize, reopened, ready_for_review]
+    types: [ opened, synchronize, reopened, ready_for_review ]
   schedule:
     - cron: '0 0 * * *' # Runs at 12:00 UTC every day
 
 jobs:
-  setup:
+  build:
     runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request' || !contains(github.event.pull_request.labels.*.name, 'auto-generated')
 
     steps:
       - name: Checkout repository
@@ -27,21 +28,12 @@ jobs:
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
 
-  build:
-    runs-on: ubuntu-latest
-    needs: setup
-    if: github.event_name != 'pull_request' || !contains(github.event.pull_request.labels.*.name, 'auto-generated')
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
       - name: Build and run tests
         run: ./gradlew build
 
   scheduled-tasks:
     runs-on: ubuntu-latest
-    needs: [setup, build]
+    needs: [ build ]
     if: github.event_name == 'schedule'
 
     steps:


### PR DESCRIPTION
### TL;DR
Optimized CI workflow by combining setup and build jobs, and removed an empty test file.

### What changed?
- Merged the `setup` and `build` jobs into a single `build` job to reduce workflow execution time
- Fixed spacing in workflow trigger types array
- Simplified job dependencies by removing the separate setup step
- Removed empty `testfile.txt`

### How to test?
1. Create a new PR to verify the CI workflow runs correctly
2. Add an 'auto-generated' label to a PR to confirm the build job is skipped
3. Verify that scheduled tasks still execute as expected at midnight UTC

### Why make this change?
The separate setup job was redundant and increased pipeline execution time. Combining the jobs streamlines the CI process while maintaining the same functionality. The empty test file served no purpose and was removed to keep the codebase clean.