### PR TITLE
Run CI workflow on non-draft PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,9 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    if: github.event_name != 'pull_request' || !contains(github.event.pull_request.labels.*.name, 'auto-generated')
+    if: github.event_name != 'pull_request' ||
+      !contains(github.event.pull_request.labels.*.name, 'auto-generated') ||
+      ${{ github.event.pull_request.draft == false }}
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
Update CI workflow condition

Adds draft PR check to CI workflow skip condition, ensuring CI only runs on non-draft PRs.