### PR TITLE
Add pretty JSON diff output to automated PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,9 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: generated-json-files
-          path: cache/NSW_STOPS.json
+          path: |
+            cache/NSW_STOPS.json
+            cache/NSW_STOPS_PRETTY.json
 
       - name: Create new folder for artifact
         run: mkdir -p ./nswstops
@@ -87,6 +89,8 @@ jobs:
             echo "No changes detected. Skipping PR creation."
             exit 0
           fi
+          git diff --cached --unified=0 --word-diff=porcelain main -- cache/NSW_STOPS_PRETTY.json > diff_output.txt
+          echo "DIFF_OUTPUT=$(cat diff_output.txt)" >> $GITHUB_ENV
 
       - name: Create Branch
         run: |
@@ -109,7 +113,12 @@ jobs:
           title: 'Add generated NSW_STOPS.json'
           body: |
             ### Description
-            Automated PR to add GTFS Stops as a JSON files.
+            Automated PR to add GTFS Stops as JSON files.
+
+            ### Diff for NSW_STOPS_PRETTY.json
+            ```
+            ${{ env.DIFF_OUTPUT }}
+            ```
 
       - name: Auto Approve PR
         uses: hmarr/auto-approve-action@v4

--- a/.gitignore
+++ b/.gitignore
@@ -75,3 +75,5 @@ local.properties
 .idea/
 .idea/misc.xml
 ./idea/vcs.xml
+
+diff_output.txt


### PR DESCRIPTION
### TL;DR
Enhanced GitHub Actions workflow to include a pretty-printed JSON file and display file differences in pull requests.

### What changed?
- Added `NSW_STOPS_PRETTY.json` to the artifact upload process
- Implemented diff generation for the pretty-printed JSON file
- Updated PR template to display file differences in the description
- Added `diff_output.txt` to `.gitignore`

### How to test?
1. Run the GitHub Actions workflow
2. Verify both JSON files are uploaded as artifacts
3. Check that created PRs include the diff output for `NSW_STOPS_PRETTY.json`
4. Confirm the diff is properly formatted in the PR description

### Why make this change?
To improve visibility of changes between JSON file updates by providing a human-readable diff in pull requests, making it easier for reviewers to understand what changed in the data.