### PR TITLE
Add NO_CHANGES flag to prevent empty PR creation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,12 +87,15 @@ jobs:
           git add .
           if git diff --staged --quiet; then
             echo "No changes detected. Skipping PR creation."
+            echo "NO_CHANGES=true" >> $GITHUB_ENV
             exit 0
           fi
           git diff --cached --unified=0 --word-diff=porcelain main -- cache/NSW_STOPS_PRETTY.json > diff_output.txt
           echo "DIFF_OUTPUT=$(cat diff_output.txt)" >> $GITHUB_ENV
+          echo "NO_CHANGES=false" >> $GITHUB_ENV
 
       - name: Create Branch
+        if: env.NO_CHANGES == 'false'
         run: |
           timestamp=$(date +'%s')
           branch_name="nsw-gtfs-stops-${timestamp}"
@@ -101,6 +104,7 @@ jobs:
           echo "BRANCH_NAME=$branch_name" >> $GITHUB_ENV
 
       - name: Create Pull Request
+        if: env.NO_CHANGES == 'false'
         uses: peter-evans/create-pull-request@v7
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -122,6 +126,6 @@ jobs:
 
       - name: Auto Approve PR
         uses: hmarr/auto-approve-action@v4
-        if: github.actor == 'github-actions[bot]'
+        if: env.NO_CHANGES == 'false' && github.actor == 'github-actions[bot]'
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### TL;DR
Added conditional checks to prevent creating empty pull requests when no changes are detected.

### What changed?
- Added a `NO_CHANGES` environment variable to track when changes are detected
- Added conditional checks to skip branch creation and PR creation steps when no changes exist
- Updated the auto-approve action to only run when changes are detected
- Maintained existing PR creation workflow for cases with actual changes

### How to test?
1. Run the CI workflow with no changes to the NSW stops file
2. Verify no PR is created
3. Run the CI workflow with changes to the NSW stops file
4. Verify PR is created and auto-approved as expected

### Why make this change?
To prevent the creation of empty pull requests when the NSW stops data hasn't changed, reducing noise in the repository and making the automation more efficient.