### PR TITLE
Fix multiline diff output in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,8 +91,12 @@ jobs:
             exit 0
           fi
           git diff --cached --unified=0 --word-diff=porcelain main -- cache/NSW_STOPS_PRETTY.json > diff_output.txt
-          echo "DIFF_OUTPUT=$(cat diff_output.txt)" >> $GITHUB_ENV
           echo "NO_CHANGES=false" >> $GITHUB_ENV
+          {
+            echo "DIFF_OUTPUT<<EOF"
+            cat diff_output.txt
+            echo "EOF"
+          } >> "$GITHUB_ENV"
 
       - name: Create Branch
         if: env.NO_CHANGES == 'false'


### PR DESCRIPTION
### TL;DR
Fixed GitHub Actions workflow environment variable handling for large diffs

### What changed?
Updated the CI workflow to properly handle multiline diff outputs by using GitHub Actions' multiline syntax (`<<EOF`) when setting the `DIFF_OUTPUT` environment variable

### How to test?
1. Make changes to the NSW_STOPS_PRETTY.json file
2. Push the changes and verify the CI workflow runs successfully
3. Confirm that large diffs are properly captured in the created pull requests

### Why make this change?
The previous implementation was using a single-line approach to set the environment variable, which could fail with large diffs. This change implements the proper heredoc-style syntax recommended by GitHub Actions for handling multiline strings in environment variables.