### PR TITLE
Reuse json objects

### DIFF
--- a/src/main/kotlin/app/krail/kgtfs/io/FileStorage.kt
+++ b/src/main/kotlin/app/krail/kgtfs/io/FileStorage.kt
@@ -9,8 +9,12 @@ import java.io.File
 
 object FileStorage {
 
-    private val prettyJson = Json { prettyPrint = true }
-    private val json = Json { prettyPrint = false }
+    val prettyJson = Json { prettyPrint = true }
+    val json = Json { prettyPrint = false }
+
+    const val ZIP_EXTENSION = ".zip"
+    const val TXT_EXTENSION = ".txt"
+    const val JSON_EXTENSION = ".json"
 
     suspend fun saveFile(fileName: String, data: ByteArray, directory: String) = withContext(Dispatchers.IO) {
         val dir = File(directory)
@@ -33,7 +37,7 @@ object FileStorage {
         pretty: Boolean = false
     ) = withContext(Dispatchers.IO) {
         // Configure JSON serializer based on the 'pretty' flag
-        val json = if (pretty) Json { prettyPrint = true } else Json
+        val json = if (pretty) prettyJson else json
 
         // Create the formatted file name (adds "PRETTY" if pretty is true)
         val finalFileName = if (pretty) "${fileName}_PRETTY$JSON_EXTENSION" else "$fileName$JSON_EXTENSION"
@@ -41,8 +45,4 @@ object FileStorage {
         // Write the serialized JSON data to the specified file path
         File(path.toFile(), finalFileName).writeText(json.encodeToString(data))
     }
-
-    const val ZIP_EXTENSION = ".zip"
-    const val TXT_EXTENSION = ".txt"
-    const val JSON_EXTENSION = ".json"
 }


### PR DESCRIPTION
### TL;DR
Made JSON serializers and file extensions publicly accessible in FileStorage object and optimized JSON serializer usage.

### What changed?
- Changed `prettyJson` and `json` properties from private to public visibility
- Moved file extension constants to the top of the FileStorage object
- Updated `saveJsonFile` to use existing JSON serializer instances instead of creating new ones

### How to test?
1. Verify that external code can access `prettyJson` and `json` serializers
2. Confirm JSON files are still saved correctly with both pretty and compact formatting
3. Ensure file extensions are properly applied when saving files

### Why make this change?
- Allows reuse of JSON serializer instances across the codebase, preventing unnecessary object creation
- Improves code organization by grouping constants at the top
- Enables external components to utilize the same JSON serializer configurations for consistency