### PR TITLE
Refactor: create NswStopsJsonIO

### DIFF
--- a/src/main/kotlin/app/krail/kgtfs/Main.kt
+++ b/src/main/kotlin/app/krail/kgtfs/Main.kt
@@ -1,5 +1,6 @@
 package app.krail.kgtfs
 
+import app.krail.kgtfs.io.NswStopsJsonIO.writeStopData
 import app.krail.kgtfs.nsw.NswGtfsManager
 import kotlinx.coroutines.runBlocking
 import kotlin.system.exitProcess
@@ -8,7 +9,10 @@ fun main() {
     println("Welcome to KRAIL GTFS")
 
     runBlocking {
-        NswGtfsManager.fetch(refresh = false,)
+        NswGtfsManager.fetch(refresh = false)
+            .let {
+                writeStopData(it)
+            }
         exitProcess(0)
     }
 }

--- a/src/main/kotlin/app/krail/kgtfs/io/NswStopsJsonIO.kt
+++ b/src/main/kotlin/app/krail/kgtfs/io/NswStopsJsonIO.kt
@@ -1,0 +1,36 @@
+package app.krail.kgtfs.io
+
+import app.krail.kgtfs.io.FileStorage.writeJsonToFile
+import app.krail.kgtfs.io.NswStopsProtoIO.readProtoFile
+import app.krail.kgtfs.io.NswStopsProtoIO.writeProtoFile
+import app.krail.kgtfs.model.StopJson
+import app.krail.kgtfs.network.cacheDirPath
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+object NswStopsJsonIO {
+
+    suspend fun writeStopData(result: List<StopJson>) = withContext(Dispatchers.IO) {
+        // Write as pretty JSON
+        writeJsonToFile(
+            data = result,
+            path = cacheDirPath,
+            fileName = "NSW_STOPS",
+            pretty = true,
+        )
+
+        // Write as compact JSON
+        writeJsonToFile(
+            data = result,
+            path = cacheDirPath,
+            fileName = "NSW_STOPS",
+            pretty = false,
+        )
+
+        // Write as Protobuf
+        writeProtoFile(data = result, filePath = "$cacheDirPath/NSW_STOPS.pb")
+
+        // Only for testing purposes
+        readProtoFile("$cacheDirPath/NSW_STOPS.pb")
+    }
+}

--- a/src/main/kotlin/app/krail/kgtfs/nsw/NswGtfsManager.kt
+++ b/src/main/kotlin/app/krail/kgtfs/nsw/NswGtfsManager.kt
@@ -1,11 +1,7 @@
 package app.krail.kgtfs.nsw
 
-import app.krail.kgtfs.io.FileStorage.writeJsonToFile
-import app.krail.kgtfs.io.NswStopsProtoIO.readProtoFile
-import app.krail.kgtfs.io.NswStopsProtoIO.writeProtoFile
 import app.krail.kgtfs.model.GtfsStop
 import app.krail.kgtfs.model.StopJson
-import app.krail.kgtfs.network.cacheDirPath
 import app.krail.kgtfs.nsw.NswTransport.fetchAndProcessNswTransportData
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -21,7 +17,7 @@ object NswGtfsManager {
     suspend fun fetch(
         refresh: Boolean = true,
         modes: List<NswTransportModeType> = NswTransportModeType.entries.filterNot { it == NswTransportModeType.COACH }
-    ) = withContext(Dispatchers.Default) {
+    ): List<StopJson> = withContext(Dispatchers.Default) {
 
         val gtfsStopMap = modes.associateWith { mode ->
             mode.fetchAndProcessNswTransportData(fetchFromNetwork = refresh)
@@ -29,8 +25,7 @@ object NswGtfsManager {
 
         println("Map Order: ${gtfsStopMap.keys}")
 
-        val result: List<StopJson> = createCommonGtfsStops(gtfsStopMap)
-        writeStopData(result)
+        createCommonGtfsStops(gtfsStopMap)
     }
 
     /**
@@ -68,29 +63,5 @@ object NswGtfsManager {
             }
         }
         return allStops
-    }
-
-    // Replace hardcoded file-writing logic with calls to writeJsonToFile
-    private suspend fun writeStopData(result: List<StopJson>) = withContext(Dispatchers.IO) {
-        // Write as pretty JSON
-        writeJsonToFile(
-            data = result,
-            path = cacheDirPath,
-            fileName = "NSW_STOPS",
-            pretty = true,
-        )
-
-        // Write as compact JSON
-        writeJsonToFile(
-            data = result,
-            path = cacheDirPath,
-            fileName = "NSW_STOPS",
-            pretty = false,
-        )
-
-        // Write as Protobuf
-        writeProtoFile(data = result, filePath = "$cacheDirPath/NSW_STOPS.pb")
-
-        readProtoFile("$cacheDirPath/NSW_STOPS.pb")
     }
 }


### PR DESCRIPTION
This pull request includes several changes to the `kgtfs` project, focusing on refactoring the code to improve readability and maintainability. The most important changes include the introduction of a new `NswStopsJsonIO` object and the removal of redundant file-writing logic from `NswGtfsManager`.

Refactoring and code improvement:

* [`src/main/kotlin/app/krail/kgtfs/Main.kt`](diffhunk://#diff-8f0853ad0ba71f6c3d4e71531ead87915378b951489cf36541dffd732a85d2a5R3): Imported the `writeStopData` function from `NswStopsJsonIO` and updated the `main` function to use this new function. [[1]](diffhunk://#diff-8f0853ad0ba71f6c3d4e71531ead87915378b951489cf36541dffd732a85d2a5R3) [[2]](diffhunk://#diff-8f0853ad0ba71f6c3d4e71531ead87915378b951489cf36541dffd732a85d2a5L11-R15)
* [`src/main/kotlin/app/krail/kgtfs/io/NswStopsJsonIO.kt`](diffhunk://#diff-70ff8d9c2ab177911350ad2c367733f8dd4e0de67a0aad8539c50107dc5089dbR1-R36): Added a new object `NswStopsJsonIO` to handle the writing of stop data in various formats (pretty JSON, compact JSON, and Protobuf).
* [`src/main/kotlin/app/krail/kgtfs/nsw/NswGtfsManager.kt`](diffhunk://#diff-8b922bbb64873c1b52525a72d75d1a42d35a27d72000b5a4ea1d7c0e700f409bL3-L8): Removed the hardcoded file-writing logic and replaced it with the new `writeStopData` function from `NswStopsJsonIO`. Updated the `fetch` function to return a list of `StopJson` objects instead of writing the data directly. [[1]](diffhunk://#diff-8b922bbb64873c1b52525a72d75d1a42d35a27d72000b5a4ea1d7c0e700f409bL3-L8) [[2]](diffhunk://#diff-8b922bbb64873c1b52525a72d75d1a42d35a27d72000b5a4ea1d7c0e700f409bL24-R28) [[3]](diffhunk://#diff-8b922bbb64873c1b52525a72d75d1a42d35a27d72000b5a4ea1d7c0e700f409bL72-L95)