### PR TITLE
Rename KrailNswStop to NswStop in proto files

### DIFF
--- a/src/main/kotlin/app/krail/kgtfs/Main.kt
+++ b/src/main/kotlin/app/krail/kgtfs/Main.kt
@@ -9,7 +9,7 @@ fun main() {
     println("Welcome to KRAIL GTFS")
 
     runBlocking {
-        NswGtfsManager.fetch(refresh = false)
+        NswGtfsManager.fetch(refresh = true)
             .let {
                 writeStopData(it)
             }

--- a/src/main/kotlin/app/krail/kgtfs/io/NswStopsProtoIO.kt
+++ b/src/main/kotlin/app/krail/kgtfs/io/NswStopsProtoIO.kt
@@ -1,8 +1,8 @@
 package app.krail.kgtfs.io
 
 import app.krail.kgtfs.model.StopJson
-import app.krail.kgtfs.proto.KrailNswStop
-import app.krail.kgtfs.proto.KrailNswStopList
+import app.krail.kgtfs.proto.NswStop
+import app.krail.kgtfs.proto.NswStopList
 import kotlinx.datetime.Clock
 import kotlinx.datetime.DateTimeUnit
 import kotlinx.datetime.TimeZone
@@ -15,7 +15,7 @@ object NswStopsProtoIO {
     fun writeProtoFile(data: List<StopJson>, filePath: String) {
         val start = Clock.System.now()
         val stopList = data.map { stop ->
-            KrailNswStop(
+            NswStop(
                 stopId = stop.id,
                 stopName = stop.name,
                 lat = stop.lat.toDouble(),
@@ -23,8 +23,8 @@ object NswStopsProtoIO {
                 productClass = stop.productClass.map { it }
             )
         }
-        val protobufData = KrailNswStopList(nswStops = stopList)
-        val adapter = KrailNswStopList.ADAPTER
+        val protobufData = NswStopList(nswStops = stopList)
+        val adapter = NswStopList.ADAPTER
         FileOutputStream(filePath).use { output ->
             output.write(adapter.encode(protobufData))
         }
@@ -34,10 +34,10 @@ object NswStopsProtoIO {
         println("Encoded: ${stopList.size} - duration: $duration ms")
     }
 
-    fun readProtoFile(filePath: String): KrailNswStopList {
+    fun readProtoFile(filePath: String): NswStopList {
         val start = Clock.System.now()
         val decoded = FileInputStream(filePath).use { input ->
-            KrailNswStopList.ADAPTER.decode(input)
+            NswStopList.ADAPTER.decode(input)
         }
         val duration = start.until(
             Clock.System.now(), DateTimeUnit.MILLISECOND, TimeZone.currentSystemDefault()

--- a/src/main/kotlin/app/krail/kgtfs/nsw/Mapper.kt
+++ b/src/main/kotlin/app/krail/kgtfs/nsw/Mapper.kt
@@ -2,7 +2,7 @@ package app.krail.kgtfs.nsw
 
 import app.krail.kgtfs.model.GtfsStop
 import app.krail.kgtfs.model.StopJson
-import app.krail.kgtfs.proto.KrailNswStop
+import app.krail.kgtfs.proto.NswStop
 
 fun GtfsStop.toStopJson(transportModeType: NswTransportModeType): StopJson {
     return StopJson(
@@ -14,8 +14,8 @@ fun GtfsStop.toStopJson(transportModeType: NswTransportModeType): StopJson {
     )
 }
 
-fun StopJson.toKrailGtfsStop(): KrailNswStop {
-    return KrailNswStop(
+fun StopJson.toKrailGtfsStop(): NswStop {
+    return NswStop(
         stopId = id,
         stopName = name,
         lat = lat.toDouble(),

--- a/src/main/proto/KrailStop.proto
+++ b/src/main/proto/KrailStop.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 package app.krail.kgtfs.proto;
 
-message KrailNswStop {
+message NswStop {
 
   /** The stop ID is a unique identifier for the stop.   */
   string stopId = 1;
@@ -17,6 +17,6 @@ message KrailNswStop {
   repeated int32 productClass = 5;
 }
 
-message KrailNswStopList {
-  repeated KrailNswStop nswStops = 1;
+message NswStopList {
+  repeated NswStop nswStops = 1;
 }


### PR DESCRIPTION
## TL;DR
Renamed protobuf message types from KrailNswStop to NswStop for clearer naming conventions

## What changed?
- Renamed KrailNswStop to NswStop in protobuf definition
- Renamed KrailNswStopList to NswStopList
- Updated all references to these types across the codebase
- Set GTFS refresh flag to true in Main.kt

### How to test?
- Run the application
- Verify that stop data is still being correctly written and read
- Confirm protobuf serialization/deserialization continues to work as expected

### Why make this change?
The Krail prefix was redundant in the protobuf message names since the package already includes the namespace. Removing it makes the code cleaner and more maintainable while following better naming conventions.