### PR TITLE
Add bus stop stand filtering and merging

### DIFF
--- a/src/main/kotlin/app/krail/kgtfs/Main.kt
+++ b/src/main/kotlin/app/krail/kgtfs/Main.kt
@@ -1,5 +1,6 @@
 package app.krail.kgtfs
 
+import app.krail.kgtfs.filter.BusStopsFilter.filterOutBusStandData
 import app.krail.kgtfs.io.NswStopsJsonIO.writeStopData
 import app.krail.kgtfs.nsw.NswGtfsManager
 import kotlinx.coroutines.runBlocking
@@ -9,7 +10,8 @@ fun main() {
     println("Welcome to KRAIL GTFS")
 
     runBlocking {
-        NswGtfsManager.fetch(refresh = true)
+        NswGtfsManager.fetch(refresh = false)
+            .let(::filterOutBusStandData)
             .let {
                 writeStopData(it)
             }

--- a/src/main/kotlin/app/krail/kgtfs/filter/BusStopsFilter.kt
+++ b/src/main/kotlin/app/krail/kgtfs/filter/BusStopsFilter.kt
@@ -1,0 +1,24 @@
+package app.krail.kgtfs.filter
+
+import app.krail.kgtfs.model.StopJson
+
+object BusStopsFilter {
+
+    fun filterOutBusStandData(data: List<StopJson>): List<StopJson> {
+        val pattern = Regex("([,-]?\\s*Stand\\s+[A-Za-z0-9/]+)\\b")
+
+        // Normalize names by removing 'Stand' followed by letters, numbers, or fractions from every entry
+        val cleanedData = data.map { stop ->
+            stop.copy(name = stop.name.replace(pattern, "").trim())
+        }
+
+        // Merge entries with the same cleaned-up name
+        return cleanedData.groupBy { it.name }
+            .map { (key, stops) ->
+                stops.reduce { acc, stop ->
+                    val mergedProductClass = acc.productClass.toMutableSet().apply { addAll(stop.productClass) }
+                    acc.copy(name = key, productClass = mergedProductClass)
+                }
+            }
+    }
+}

--- a/src/main/kotlin/app/krail/kgtfs/io/NswStopsJsonIO.kt
+++ b/src/main/kotlin/app/krail/kgtfs/io/NswStopsJsonIO.kt
@@ -10,7 +10,7 @@ import kotlinx.coroutines.withContext
 
 object NswStopsJsonIO {
 
-    suspend fun writeStopData(result: List<StopJson>) = withContext(Dispatchers.IO) {
+    suspend fun writeStopData(result: List<StopJson>): Unit = withContext(Dispatchers.IO) {
         // Write as pretty JSON
         writeJsonToFile(
             data = result,

--- a/src/test/kotlin/app/krail/gtfs/filter/BusStopFilterTest.kt
+++ b/src/test/kotlin/app/krail/gtfs/filter/BusStopFilterTest.kt
@@ -1,0 +1,43 @@
+package app.krail.gtfs.filter
+
+import app.krail.kgtfs.filter.BusStopsFilter.filterOutBusStandData
+import app.krail.kgtfs.model.StopJson
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class BusStopFilterTest {
+
+    @Test
+    fun testFilterOutBusStandData() {
+        val input = listOf(
+            StopJson("1", "Central Station, Railway Square, Stand L", "1.0", "1.0", mutableSetOf(1)),
+            StopJson("2", "Central Station, Railway Square, Stand K", "1.0", "1.0", mutableSetOf(2)),
+            StopJson("3", "Town Hall, Stand A", "2.0", "2.0", mutableSetOf(3)),
+            StopJson("4", "Town Hall, Stand B", "2.0", "2.0", mutableSetOf(4)),
+            StopJson("5", "Museum Station", "3.0", "3.0", mutableSetOf(5)),
+            StopJson("6", "Central Station, Chalmers St, Stand G", "6.0", "6.0", mutableSetOf(5)),
+            StopJson("7", "Macarthur Square, Kellicar Rd, Stand 1/2", "7.0", "7.0", mutableSetOf(5)),
+            StopJson("8", "Macarthur Square, Kellicar Rd, Stand 4", "8.0", "8.0", mutableSetOf(5)),
+            StopJson("9", "Merrylands Interchange, Terminal Pl - Stand 2", "8.0", "8.0", mutableSetOf(5)),
+            StopJson("10", "Westpoint Bus Interchange, Stand 10", "10.0", "10.0", mutableSetOf(5)),
+        )
+
+        val expected = listOf(
+            StopJson("1", "Central Station, Railway Square", "1.0", "1.0", mutableSetOf(1, 2)),
+            StopJson("3", "Town Hall", "2.0", "2.0", mutableSetOf(3, 4)),
+            StopJson("5", "Museum Station", "3.0", "3.0", mutableSetOf(5)),
+            StopJson("5", "Central Station, Chalmers St", "6.0", "6.0", mutableSetOf(5)),
+            StopJson("7", "Macarthur Square, Kellicar Rd", "7.0", "7.0", mutableSetOf(5)),
+            StopJson("9", "Merrylands Interchange, Terminal Pl", "8.0", "8.0", mutableSetOf(5)),
+            StopJson("10", "Westpoint Bus Interchange", "10.0", "10.0", mutableSetOf(5)),
+        )
+
+        val result = filterOutBusStandData(input)
+
+        assertEquals(expected.size, result.size)
+        for (i in expected.indices) {
+            assertEquals(expected[i].name, result[i].name)
+            assertEquals(expected[i].productClass, result[i].productClass)
+        }
+    }
+}


### PR DESCRIPTION
### TL;DR
Added filtering logic to merge bus stops with different stand numbers into single locations.

### What changed?
- Created a new `BusStopsFilter` class with logic to remove stand numbers from stop names
- Added regex pattern matching to identify and remove various stand number formats
- Implemented merging logic to combine product classes for stops at the same location
- Modified the main application flow to include the new filtering step
- Added unit tests to verify the filtering behavior

### How to test?
1. Run the unit tests in `BusStopFilterTest`
2. Execute the main application and verify the output JSON
3. Check that stops like "Central Station, Stand A" and "Central Station, Stand B" are merged into a single "Central Station" entry
4. Verify that product classes from merged stops are combined correctly

### Why make this change?
Bus stops at the same location but with different stand numbers were appearing as separate entries, creating unnecessary duplication in the data. This change consolidates these entries to provide a cleaner, more usable dataset while preserving the service information from all stands.