### PR TITLE
CI: Remove auto-generated label check from workflow condition

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,9 +13,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    if: github.event_name != 'pull_request' ||
-      !contains(github.event.pull_request.labels.*.name, 'auto-generated') ||
-      ${{ github.event.pull_request.draft == false }}
+    if: github.event_name != 'pull_request' || ${{ github.event.pull_request.draft == false }}
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
### TL;DR

Simplified CI workflow condition to only check for draft PRs.

### What changed?

Removed the condition that skipped CI for pull requests labeled as "auto-generated". Now the CI workflow will run for all non-draft pull requests, regardless of their labels.

### How to test?

1. Create a regular pull request and verify that CI runs
2. Create a draft pull request and verify that CI does not run
3. Create a pull request with the "auto-generated" label and verify that CI now runs (previously it would have been skipped)

### Why make this change?

This change streamlines the CI process by removing the special handling for "auto-generated" labeled PRs. This simplifies the workflow logic and ensures consistent CI behavior across all non-draft pull requests, improving visibility into the build status of all meaningful changes.