### PR TITLE
Fix CI workflow condition for pull request draft check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,11 +9,11 @@ on:
     types: [ opened, synchronize, reopened, ready_for_review ]
   schedule:
     - cron: '0 0 */3 * *' # Runs at 12:00 UTC every 3 days
-  
+
 jobs:
   build:
     runs-on: ubuntu-latest
-    if: github.event_name != 'pull_request' || ${{ github.event.pull_request.draft == false }}
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft != true
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
### TL;DR

Fixed the GitHub Actions workflow condition for pull requests.

### What changed?

Modified the conditional expression in the CI workflow that determines when to run jobs on pull requests. Changed from `${{ github.event.pull_request.draft == false }}` to `github.event.pull_request.draft != true`, which is a more reliable syntax for GitHub Actions.

### How to test?

1. Create a draft pull request and verify the workflow doesn't run
2. Mark the pull request as ready for review and verify the workflow runs
3. Make changes to the pull request and verify the workflow runs on synchronize events

### Why make this change?

The previous syntax using the expression syntax (`${{...}}`) inside an `if` statement that already evaluates expressions was redundant and potentially error-prone. The new syntax is cleaner and follows GitHub Actions best practices for conditional job execution.