### PR TITLE
Consolidate Manly Wharf stops into a single entry

### DIFF
--- a/nswstops/NSW_STOPS_PRETTY.json
+++ b/nswstops/NSW_STOPS_PRETTY.json
@@ -328295,33 +328295,6 @@
     ]
   },
   {
-    "id": "20951",
-    "name": "Manly, Wharf 1",
-    "lat": "-33.80046",
-    "lon": "151.283796",
-    "productClass": [
-      9
-    ]
-  },
-  {
-    "id": "209525",
-    "name": "Manly, Wharf 2",
-    "lat": "-33.800508",
-    "lon": "151.283958",
-    "productClass": [
-      9
-    ]
-  },
-  {
-    "id": "209593",
-    "name": "Manly, Wharf 3",
-    "lat": "-33.800592",
-    "lon": "151.284619",
-    "productClass": [
-      9
-    ]
-  },
-  {
     "id": "20601",
     "name": "McMahons Point Wharf",
     "lat": "-33.848849",
@@ -330800,6 +330773,15 @@
     "lon": "151.225935",
     "productClass": [
       4
+    ]
+  },
+  {
+    "id": "209573",
+    "name": "Manly Wharf",
+    "lat": "-33.80046",
+    "lon": "151.283796",
+    "productClass": [
+      9
     ]
   }
 ]

--- a/src/main/kotlin/app/krail/kgtfs/Main.kt
+++ b/src/main/kotlin/app/krail/kgtfs/Main.kt
@@ -1,6 +1,7 @@
 package app.krail.kgtfs
 
 import app.krail.kgtfs.filter.BusStopsFilter.filterOutBusStandData
+import app.krail.kgtfs.filter.SydneyFerryFilter.processSydneyFerryData
 import app.krail.kgtfs.io.NswStopsJsonIO.writeStopData
 import app.krail.kgtfs.io.writeParkRideData
 import app.krail.kgtfs.nsw.NswGtfsManager
@@ -13,6 +14,7 @@ fun main() {
     runBlocking {
         NswGtfsManager.fetch(refresh = true)
             .let(::filterOutBusStandData)
+            .let(::processSydneyFerryData)
             .let {
                 writeStopData(it)
                 writeParkRideData(it)

--- a/src/main/kotlin/app/krail/kgtfs/filter/SydneyFerryFilter.kt
+++ b/src/main/kotlin/app/krail/kgtfs/filter/SydneyFerryFilter.kt
@@ -1,7 +1,6 @@
 package app.krail.kgtfs.filter
 
 import app.krail.kgtfs.model.StopJson
-import app.krail.kgtfs.nsw.NswTransportModeType
 
 object SydneyFerryFilter {
 
@@ -9,17 +8,28 @@ object SydneyFerryFilter {
         "20951" to Pair("209573", "Manly Wharf"),
         "209525" to Pair("209573", "Manly Wharf"),
         "209593" to Pair("209573", "Manly Wharf")
-        // Add more replacement rules here in the future.
+        // Add more replacements todo - for Circular Quay Wharf, and Barangaroo Wharf
     )
 
     fun processSydneyFerryData(data: List<StopJson>): List<StopJson> {
-        val processedList = data.map { stop ->
-            REPLACEMENT_MAP[stop.id]?.let { (newId, _) ->
-                stop.copy(id = newId)
-            } ?: stop
+        // Partition the list into stops that need replacement and those that do not.
+        val (toReplace, toKeep) = data.partition { it.id in REPLACEMENT_MAP }
+
+        // If there's nothing to replace, return the original list to avoid further processing.
+        if (toReplace.isEmpty()) {
+            println("SydneyFerryFilter: No stops to replace, returning original data.")
+            return data
         }
 
-        // Remove duplicates that may have been introduced by the mapping.
-        return processedList.distinctBy { it.id }
+        // Map only the necessary stops to their new IDs.
+        val replaced = toReplace.map { stop ->
+            REPLACEMENT_MAP[stop.id]?.let { (newId, name) ->
+                println("SydneyFerryFilter: Replacing stop ID ${stop.id} with $newId")
+                stop.copy(id = newId, name = name)
+            } ?: stop // Fallback, though partition ensures it's never null.
+        }
+
+        // Combine the lists and remove duplicates.
+        return (toKeep + replaced).distinctBy { it.id }
     }
 }

--- a/src/main/kotlin/app/krail/kgtfs/filter/SydneyFerryFilter.kt
+++ b/src/main/kotlin/app/krail/kgtfs/filter/SydneyFerryFilter.kt
@@ -1,0 +1,25 @@
+package app.krail.kgtfs.filter
+
+import app.krail.kgtfs.model.StopJson
+import app.krail.kgtfs.nsw.NswTransportModeType
+
+object SydneyFerryFilter {
+
+    private val REPLACEMENT_MAP = mapOf(
+        "20951" to Pair("209573", "Manly Wharf"),
+        "209525" to Pair("209573", "Manly Wharf"),
+        "209593" to Pair("209573", "Manly Wharf")
+        // Add more replacement rules here in the future.
+    )
+
+    fun processSydneyFerryData(data: List<StopJson>): List<StopJson> {
+        val processedList = data.map { stop ->
+            REPLACEMENT_MAP[stop.id]?.let { (newId, _) ->
+                stop.copy(id = newId)
+            } ?: stop
+        }
+
+        // Remove duplicates that may have been introduced by the mapping.
+        return processedList.distinctBy { it.id }
+    }
+}


### PR DESCRIPTION
# Consolidate Manly Wharf Stops

This PR consolidates multiple Manly Wharf entries (Wharf 1, 2, and 3) into a single "Manly Wharf" entry to simplify the user experience. 

The implementation:
- Removes the three separate Manly Wharf entries (IDs: 20951, 209525, 209593)
- Adds a single consolidated "Manly Wharf" entry (ID: 209573)
- Creates a new SydneyFerryFilter that handles the replacement logic
- Updates the main processing pipeline to include the ferry filter

This is the first step in a larger effort to consolidate multiple wharf entries at other locations (Circular Quay, Barangaroo) in the future.