### PR TITLE
feat: track datasets for KRAIL-BFF live trip tracking

### DIFF
--- a/.github/workflows/track-dataset.yml
+++ b/.github/workflows/track-dataset.yml
@@ -1,0 +1,70 @@
+name: Build Track Datasets
+
+# Builds the tracking datasets consumed by KRAIL-BFF live trip tracking
+# (platform-level stop directory + per-mode shapes polylines) and publishes
+# them to the rolling `track-latest` GitHub Release.
+#
+# The BFF points TRACK_DATASET_MANIFEST_URL at
+#   https://github.com/ksharma-xyz/KRAIL-GTFS/releases/download/track-latest/track_manifest.json
+# and hot-swaps in memory when the manifest version bumps — no PR or deploy
+# needed on the BFF side. A failed run here is harmless: the BFF keeps
+# serving the previous release and falls back gracefully if none exists.
+#
+# Standalone and additive: does NOT touch the stops/routes pipeline (ci.yml).
+
+on:
+  workflow_dispatch:
+    inputs:
+      reason:
+        description: 'Reason for manual trigger'
+        required: false
+        type: string
+  schedule:
+    # Weekly, Sundays 16:00 UTC ≈ Mon 03:00 AEDT / 02:00 AEST
+    - cron: '0 16 * * 0'
+
+permissions:
+  contents: write  # create/update the track-latest release
+
+concurrency:
+  group: track-dataset
+  cancel-in-progress: false
+
+env:
+  JAVA_VERSION: '21'
+
+jobs:
+  build-and-release:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up JDK
+        uses: actions/setup-java@v5
+        with:
+          distribution: zulu
+          java-version: ${{ env.JAVA_VERSION }}
+
+      - name: Build track datasets
+        env:
+          NSW_TRANSPORT_API_KEY: ${{ secrets.NSW_TRANSPORT_API_KEY }}
+        run: ./gradlew buildTrackDataset -PoutDir=cache/track
+
+      - name: Inspect output
+        run: |
+          ls -la cache/track
+          cat cache/track/track_manifest.json
+
+      - name: Publish to rolling track-latest release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          # Recreate the rolling release so stale assets never linger.
+          gh release delete track-latest --yes --cleanup-tag || true
+          gh release create track-latest \
+            --title "Track datasets (rolling)" \
+            --notes "KRAIL-BFF tracking datasets. Regenerated $(date -u +'%Y-%m-%d %H:%M UTC') from NSW Open Data GTFS. Version: see track_manifest.json." \
+            cache/track/*.pb \
+            cache/track/track_manifest.json

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -68,6 +68,23 @@ tasks.register<JavaExec>("runKRAIL-GTFS") {
     classpath = sourceSets["main"].runtimeClasspath
 }
 
+// Build the KRAIL-BFF tracking datasets (platform stop directory + per-mode
+// shapes polylines + manifest). Standalone — does not touch the stops/routes
+// pipeline. Used by .github/workflows/track-dataset.yml (weekly cron).
+// Args (positional): <outDir> <version> <releaseUrlBase> — all optional.
+tasks.register<JavaExec>("buildTrackDataset") {
+    group = "application"
+    description = "Build track_stops.pb + shapes_<mode>.pb + track_manifest.json for KRAIL-BFF tracking"
+    mainClass.set("app.krail.kgtfs.track.TrackDatasetBuilderKt")
+    classpath = sourceSets["main"].runtimeClasspath
+    args = listOf(
+        project.findProperty("outDir")?.toString() ?: "",
+        // NOT "version" — that collides with Gradle's built-in project.version.
+        project.findProperty("datasetVersion")?.toString() ?: "",
+        project.findProperty("releaseUrlBase")?.toString() ?: "",
+    )
+}
+
 wire {
     kotlin {
         javaInterop = true

--- a/docs/TrackDatasets.md
+++ b/docs/TrackDatasets.md
@@ -1,0 +1,57 @@
+# Track Datasets (KRAIL-BFF live trip tracking)
+
+This repo also builds the datasets that power **live trip tracking** in
+[KRAIL-BFF](https://github.com/ksharma-xyz/KRAIL-BFF) — separate from, and
+additive to, the stops/routes pipeline that updates the KRAIL app.
+
+## What gets built
+
+| Artifact | Contents | Why |
+|---|---|---|
+| `track_stops.pb` | Platform-level stop directory, merged across modes: raw GTFS `stop_id`, name, `parent_station`, lat/lon. Includes `location_type` 0 (platforms/stops) **and** 1 (stations). | GTFS-Realtime reports **platform** ids for trains (e.g. `2000336` = "Central Station Platform 16"); the app's search dataset only carries parents + bus stops, so the BFF needs this to name every stop. |
+| `shapes_<bundle>.pb` | Per-mode `shape_id → encoded polyline` (Google polyline, precision 5) plus `trip_id → shape_id` index. Deduped: thousands of trips share a handful of shapes. | The BFF returns the route line for the map on the first tracking poll, keyed by the realtime trip id. |
+| `track_manifest.json` | `{version, generated_at, artifacts:[{name, url, sha256, size_bytes}]}` | The BFF fetches this, verifies sha256, and hot-swaps datasets in memory when `version` changes. |
+
+Bundles: sydneytrains, nswtrains, metro, lightrail (consolidated), and
+sydney ferries. **Buses are excluded** — bus shapes are 10–50× larger; the
+BFF draws straight-line geometry for buses instead.
+
+Schema: [`src/main/proto/TrackDataset.proto`](../src/main/proto/TrackDataset.proto).
+The field numbers/types are a wire contract with the BFF's decoder
+(`KRAIL-BFF/server/src/main/proto/nsw/track-dataset.proto`) — change both
+together or not at all.
+
+## How it runs
+
+`.github/workflows/track-dataset.yml` — weekly cron (Sun 16:00 UTC) +
+manual `workflow_dispatch`:
+
+1. `./gradlew buildTrackDataset` downloads the GTFS bundles (using the
+   `NSW_TRANSPORT_API_KEY` repo secret, same as the stops pipeline) and
+   derives the artifacts into `cache/track/`.
+2. The job recreates the **rolling `track-latest` GitHub Release** with the
+   fresh artifacts. Nothing is committed to git — these are machine-derived
+   binaries, regenerated weekly.
+
+## How KRAIL-BFF stays up to date — no PRs needed
+
+The BFF's `TRACK_DATASET_MANIFEST_URL` points at:
+
+```
+https://github.com/ksharma-xyz/KRAIL-GTFS/releases/download/track-latest/track_manifest.json
+```
+
+It re-checks the manifest every ~6 hours and hot-swaps in memory when the
+version bumps. A failed or missing release degrades gracefully on the BFF
+side (search-dataset stop names, straight-line map lines) — this workflow
+can never break tracking, only un-enhance it.
+
+## Local run
+
+```bash
+./gradlew buildTrackDataset            # needs NSW_TRANSPORT_API_KEY (env or local.properties)
+ls cache/track                          # track_stops.pb, shapes_*.pb, track_manifest.json
+```
+
+Point a locally running BFF at the output with
+`TRACK_DATASET_DIR=/path/to/KRAIL-GTFS/cache/track`.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -73,6 +73,7 @@ nav:
   - Data Formats: DataFormats.md
   - Bus Route Logic: BusRouteLogic.md
   - CI/CD Pipeline: CICD.md
+  - Track Datasets (BFF): TrackDatasets.md
 
 extra:
   social:

--- a/src/main/kotlin/app/krail/kgtfs/track/GtfsCsv.kt
+++ b/src/main/kotlin/app/krail/kgtfs/track/GtfsCsv.kt
@@ -1,0 +1,60 @@
+package app.krail.kgtfs.track
+
+import java.io.File
+
+/**
+ * Minimal, LENIENT RFC 4180-ish CSV parser for the track dataset builder:
+ * handles quoted fields, escaped quotes (""), optional UTF-8 BOM, and the
+ * malformed quoting NSW ships in some bundles (e.g. nswtrains stops.txt has
+ * stray characters after a closing quote, which strict parsers reject).
+ * Returns one Map per row keyed by the header row.
+ */
+internal object GtfsCsv {
+
+    fun readWithHeader(file: File): List<Map<String, String>> {
+        val rows = parse(file.readText())
+        val header = rows.firstOrNull() ?: return emptyList()
+        return rows.drop(1).map { row ->
+            buildMap {
+                header.forEachIndexed { i, key -> put(key, row.getOrNull(i).orEmpty()) }
+            }
+        }
+    }
+
+    fun parse(input: String): List<List<String>> {
+        val source = if (input.isNotEmpty() && input[0] == '﻿') input.substring(1) else input
+        val rows = mutableListOf<List<String>>()
+        val current = mutableListOf<String>()
+        val field = StringBuilder()
+        var inQuotes = false
+        var i = 0
+        while (i < source.length) {
+            val c = source[i]
+            when {
+                inQuotes -> when {
+                    c == '"' && i + 1 < source.length && source[i + 1] == '"' -> {
+                        field.append('"'); i++
+                    }
+                    c == '"' -> inQuotes = false
+                    else -> field.append(c)
+                }
+                c == '"' -> inQuotes = true
+                c == ',' -> {
+                    current.add(field.toString()); field.setLength(0)
+                }
+                c == '\n' -> {
+                    current.add(field.toString()); field.setLength(0)
+                    rows.add(current.toList()); current.clear()
+                }
+                c == '\r' -> { /* swallow; treat as part of CRLF */ }
+                else -> field.append(c)
+            }
+            i++
+        }
+        if (field.isNotEmpty() || current.isNotEmpty()) {
+            current.add(field.toString())
+            rows.add(current.toList())
+        }
+        return rows
+    }
+}

--- a/src/main/kotlin/app/krail/kgtfs/track/Polyline.kt
+++ b/src/main/kotlin/app/krail/kgtfs/track/Polyline.kt
@@ -1,0 +1,67 @@
+package app.krail.kgtfs.track
+
+/**
+ * Google polyline algorithm, precision 5 — the encoding the KRAIL-BFF
+ * track contract promises in `LegGeometry.encoded_polyline`. Encode is
+ * used by the track dataset builder; decode exists for tests.
+ */
+object Polyline {
+
+    data class Point(val lat: Double, val lon: Double)
+
+    fun encode(points: List<Point>): String {
+        val sb = StringBuilder()
+        var prevLat = 0L
+        var prevLon = 0L
+        for (p in points) {
+            val lat = Math.round(p.lat * 1e5)
+            val lon = Math.round(p.lon * 1e5)
+            encodeValue(lat - prevLat, sb)
+            encodeValue(lon - prevLon, sb)
+            prevLat = lat
+            prevLon = lon
+        }
+        return sb.toString()
+    }
+
+    fun decode(encoded: String): List<Point> {
+        val points = mutableListOf<Point>()
+        var index = 0
+        var lat = 0L
+        var lon = 0L
+        while (index < encoded.length) {
+            val (dLat, i1) = decodeValue(encoded, index)
+            val (dLon, i2) = decodeValue(encoded, i1)
+            index = i2
+            lat += dLat
+            lon += dLon
+            points.add(Point(lat / 1e5, lon / 1e5))
+        }
+        return points
+    }
+
+    private fun encodeValue(value: Long, sb: StringBuilder) {
+        var v = value shl 1
+        if (value < 0) v = v.inv()
+        while (v >= 0x20) {
+            sb.append((((v and 0x1f) or 0x20) + 63).toInt().toChar())
+            v = v shr 5
+        }
+        sb.append((v + 63).toInt().toChar())
+    }
+
+    private fun decodeValue(encoded: String, start: Int): Pair<Long, Int> {
+        var index = start
+        var result = 0L
+        var shift = 0
+        while (true) {
+            val b = (encoded[index].code - 63).toLong()
+            index++
+            result = result or ((b and 0x1f) shl shift)
+            shift += 5
+            if (b < 0x20) break
+        }
+        val value = if (result and 1L != 0L) (result shr 1).inv() else result shr 1
+        return value to index
+    }
+}

--- a/src/main/kotlin/app/krail/kgtfs/track/TrackDatasetBuilder.kt
+++ b/src/main/kotlin/app/krail/kgtfs/track/TrackDatasetBuilder.kt
@@ -1,0 +1,207 @@
+package app.krail.kgtfs.track
+
+import app.krail.kgtfs.io.FileStorage.saveFile
+import app.krail.kgtfs.io.ZipFileManager.unzip
+import app.krail.kgtfs.network.NswGtfsService
+import app.krail.kgtfs.network.cacheDirectory
+import app.krail.kgtfs.nsw.NswTransportModeType
+import app.krail.kgtfs.proto.ShapesDataset
+import app.krail.kgtfs.proto.TrackStop
+import app.krail.kgtfs.proto.TrackStopsDataset
+import io.ktor.client.statement.HttpResponse
+import io.ktor.client.statement.readRawBytes
+import kotlinx.coroutines.runBlocking
+import okio.Path.Companion.toPath
+import java.io.File
+import java.security.MessageDigest
+import java.time.Instant
+import java.time.LocalDate
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+
+/**
+ * Builds the tracking datasets consumed by KRAIL-BFF live trip tracking
+ * (see TrackDataset.proto for the wire contract):
+ *
+ *  - `track_stops.pb`     — platform-level stop directory, merged across modes
+ *  - `shapes_<bundle>.pb` — per-mode shape_id → encoded polyline + trip index
+ *  - `track_manifest.json`— version + per-artifact url/sha256/size
+ *
+ * Standalone entry point — does NOT touch the existing stops/routes
+ * pipeline (Main.kt). Downloads its own GTFS bundles into the same cache
+ * directory layout, then derives the track artifacts.
+ *
+ * Buses are intentionally excluded: bus shapes are 10–50× larger and the
+ * BFF falls back to straight-line geometry for buses until that's solved.
+ *
+ * Usage:
+ *   ./gradlew buildTrackDataset \
+ *     [-PoutDir=cache/track] [-Pversion=YYYYMMDD] [-PreleaseUrlBase=https://...]
+ */
+fun main(args: Array<String>) = runBlocking {
+    val outDir = args.getOrNull(0)?.takeIf { it.isNotBlank() } ?: "$cacheDirectory/track"
+    val version = args.getOrNull(1)?.takeIf { it.isNotBlank() }
+        ?: LocalDate.now(ZoneId.of("Australia/Sydney")).format(DateTimeFormatter.BASIC_ISO_DATE)
+    val releaseUrlBase = (args.getOrNull(2)?.takeIf { it.isNotBlank() }
+        ?: "https://github.com/ksharma-xyz/KRAIL-GTFS/releases/download/track-latest").trimEnd('/')
+
+    println("Building track datasets v$version -> $outDir")
+
+    val out = File(outDir).apply { mkdirs() }
+    val artifacts = mutableListOf<Pair<String, ByteArray>>() // name -> bytes
+    val mergedStops = LinkedHashMap<String, TrackStop>()
+
+    for (trackMode in trackModes) {
+        val modeName = trackMode.mode.modeName
+        val gtfsDir = File("$cacheDirectory/$modeName")
+        try {
+            println("$modeName: downloading GTFS bundle")
+            val response = trackMode.fetch().getOrThrow()
+            saveFile(fileName = "$modeName.zip", data = response.readRawBytes(), directory = cacheDirectory)
+            unzip(
+                zipPath = "$cacheDirectory/$modeName.zip".toPath(),
+                destinationPath = "$cacheDirectory/$modeName".toPath(),
+            )
+        } catch (e: Exception) {
+            println("WARN: $modeName fetch failed (${e.message}); skipping mode")
+            continue
+        }
+
+        val stopsFile = File(gtfsDir, "stops.txt")
+        if (stopsFile.exists()) {
+            for (stop in buildTrackStops(GtfsCsv.readWithHeader(stopsFile))) {
+                mergedStops.putIfAbsent(stop.stop_id, stop)
+            }
+        }
+
+        val tripsFile = File(gtfsDir, "trips.txt")
+        val shapesFile = File(gtfsDir, "shapes.txt")
+        if (!tripsFile.exists() || !shapesFile.exists()) {
+            println("$modeName: no trips.txt/shapes.txt — skipping shapes")
+            continue
+        }
+        val dataset = buildShapesDataset(
+            bundleKey = trackMode.bundleKey,
+            version = version,
+            tripRows = GtfsCsv.readWithHeader(tripsFile),
+            shapeRows = GtfsCsv.readWithHeader(shapesFile),
+        )
+        if (dataset.shapes.isEmpty()) {
+            println("$modeName: 0 usable shapes — skipping")
+            continue
+        }
+        artifacts.add("shapes_${trackMode.bundleKey}.pb" to dataset.encode())
+        println("  shapes_${trackMode.bundleKey}.pb: ${dataset.shapes.size} shapes, ${dataset.trip_index.size} trips")
+    }
+
+    val directory = TrackStopsDataset(
+        version = version,
+        generated_at = Instant.now().toString(),
+        attribution = "Data © Transport for NSW (CC BY 4.0). Modified by KRAIL: GTFS → protobuf.",
+        stops = mergedStops.values.toList(),
+    )
+    artifacts.add(0, "track_stops.pb" to directory.encode())
+    println("  track_stops.pb: ${mergedStops.size} stops")
+
+    check(mergedStops.isNotEmpty()) { "no stops parsed from any bundle — refusing to publish an empty directory" }
+
+    for ((name, bytes) in artifacts) File(out, name).writeBytes(bytes)
+    File(out, "track_manifest.json").writeText(buildManifest(version, directory.generated_at, releaseUrlBase, artifacts))
+    println("Wrote ${artifacts.size} artifacts + track_manifest.json -> ${out.absolutePath}")
+}
+
+private class TrackMode(
+    val mode: NswTransportModeType,
+    val bundleKey: String,
+    val fetch: suspend () -> Result<HttpResponse>,
+)
+
+/**
+ * bundleKey must match KRAIL-BFF TrackDatasetStore.bundleKeyFor(): the
+ * per-line lightrail realtime feeds all map to "lightrail"; ferries map
+ * to "ferries_sydneyferries".
+ */
+private val trackModes = listOf(
+    TrackMode(NswTransportModeType.SYDNEY_TRAINS, "sydneytrains") { NswGtfsService.fetchSydneyTrainsGtfs() },
+    TrackMode(NswTransportModeType.NSW_TRAINS, "nswtrains") { NswGtfsService.fetchNswTrainsGtfs() },
+    TrackMode(NswTransportModeType.SYDNEY_METRO, "metro") { NswGtfsService.fetchSydneyMetroGtfs() },
+    TrackMode(NswTransportModeType.LIGHT_RAIL, "lightrail") { NswGtfsService.fetchLightRailGtfs() },
+    TrackMode(NswTransportModeType.SYDNEY_FERRY, "ferries_sydneyferries") { NswGtfsService.fetchSydneyFerriesGtfs() },
+)
+
+/** Platforms/stops (location_type 0) and stations (1) only — GTFS-R never references other types. */
+internal fun buildTrackStops(rows: List<Map<String, String>>): List<TrackStop> =
+    rows.mapNotNull { row ->
+        val id = row["stop_id"]?.takeIf { it.isNotBlank() } ?: return@mapNotNull null
+        val locationType = row["location_type"]?.toIntOrNull() ?: 0
+        if (locationType != 0 && locationType != 1) return@mapNotNull null
+        val name = row["stop_name"]?.takeIf { it.isNotBlank() } ?: return@mapNotNull null
+        TrackStop(
+            stop_id = id,
+            name = name,
+            parent_id = row["parent_station"].orEmpty(),
+            lat = row["stop_lat"]?.toDoubleOrNull() ?: 0.0,
+            lon = row["stop_lon"]?.toDoubleOrNull() ?: 0.0,
+        )
+    }
+
+internal fun buildShapesDataset(
+    bundleKey: String,
+    version: String,
+    tripRows: List<Map<String, String>>,
+    shapeRows: List<Map<String, String>>,
+): ShapesDataset {
+    // trips.txt: trip_id → shape_id (many → one)
+    val tripIndex = tripRows.mapNotNull { row ->
+        val tripId = row["trip_id"]?.takeIf { it.isNotBlank() } ?: return@mapNotNull null
+        val shapeId = row["shape_id"]?.takeIf { it.isNotBlank() } ?: return@mapNotNull null
+        tripId to shapeId
+    }.toMap()
+
+    // shapes.txt: shape_id → ordered points → encoded polyline
+    data class Pt(val seq: Int, val lat: Double, val lon: Double)
+    val pointsByShape = HashMap<String, MutableList<Pt>>()
+    for (row in shapeRows) {
+        val id = row["shape_id"]?.takeIf { it.isNotBlank() } ?: continue
+        val lat = row["shape_pt_lat"]?.toDoubleOrNull() ?: continue
+        val lon = row["shape_pt_lon"]?.toDoubleOrNull() ?: continue
+        val seq = row["shape_pt_sequence"]?.toIntOrNull() ?: continue
+        pointsByShape.getOrPut(id) { mutableListOf() }.add(Pt(seq, lat, lon))
+    }
+    val polylines = pointsByShape.mapValues { (_, pts) ->
+        Polyline.encode(pts.sortedBy { it.seq }.map { Polyline.Point(it.lat, it.lon) })
+    }
+
+    // Drop trips pointing at missing shapes; drop shapes no trip uses.
+    val usedTripIndex = tripIndex.filterValues { it in polylines }
+    val usedShapes = polylines.filterKeys { it in usedTripIndex.values.toSet() }
+
+    return ShapesDataset(
+        version = version,
+        feed = bundleKey,
+        shapes = usedShapes,
+        trip_index = usedTripIndex,
+    )
+}
+
+internal fun buildManifest(
+    version: String,
+    generatedAt: String,
+    releaseUrlBase: String,
+    artifacts: List<Pair<String, ByteArray>>,
+): String = buildString {
+    append("{\"version\":\"").append(version).append("\",")
+    append("\"generated_at\":\"").append(generatedAt).append("\",")
+    append("\"artifacts\":[")
+    artifacts.forEachIndexed { i, (name, bytes) ->
+        if (i > 0) append(',')
+        append("{\"name\":\"").append(name).append("\",")
+        append("\"url\":\"").append(releaseUrlBase).append('/').append(name).append("\",")
+        append("\"sha256\":\"").append(sha256Hex(bytes)).append("\",")
+        append("\"size_bytes\":").append(bytes.size).append('}')
+    }
+    append("]}")
+}
+
+private fun sha256Hex(bytes: ByteArray): String =
+    MessageDigest.getInstance("SHA-256").digest(bytes).joinToString("") { "%02x".format(it) }

--- a/src/main/proto/TrackDataset.proto
+++ b/src/main/proto/TrackDataset.proto
@@ -1,0 +1,47 @@
+syntax = "proto3";
+
+package app.krail.kgtfs.proto;
+
+// Tracking datasets consumed by the KRAIL-BFF live-trip-tracking feature
+// (KRAIL-BFF docs/reference/TRACKING_DESIGN.md §7a). Built weekly by
+// .github/workflows/track-dataset.yml and published to the rolling
+// `track-latest` GitHub Release; the BFF fetches them via
+// track_manifest.json (sha256-verified) and holds them in memory.
+//
+// WIRE-FORMAT CONTRACT: field numbers and types must stay identical to
+// the BFF's decoder schema (KRAIL-BFF server/src/main/proto/nsw/
+// track-dataset.proto). The Kotlin package differs per repo; the bytes
+// must not.
+
+// Platform-level stop directory: every stop row from the NSW GTFS static
+// bundles (location_type 0 stops/platforms AND 1 stations), raw GTFS ids.
+// Exists because GTFS-R reports PLATFORM ids for trains while the app's
+// search dataset carries parents + bus stops only.
+message TrackStopsDataset {
+  string version = 1;       // YYYYMMDD (Sydney time)
+  string generated_at = 2;  // ISO-8601 UTC
+  string attribution = 3;
+  repeated TrackStop stops = 4;
+}
+
+message TrackStop {
+  string stop_id = 1;    // raw GTFS id, exactly as GTFS-R reports it
+  string name = 2;       // render-ready, e.g. "Central Station Platform 16"
+  string parent_id = 3;  // stops.txt parent_station; empty for top-level
+  double lat = 4;
+  double lon = 5;
+}
+
+// Per-mode route geometry: trips.txt + shapes.txt joined and deduped.
+// Thousands of trips share a handful of shapes — shapes are stored once,
+// trips index into them.
+message ShapesDataset {
+  string version = 1;
+  string feed = 2;  // bundle key: "sydneytrains", "metro", "lightrail", ...
+
+  // shape_id -> Google encoded polyline, precision 5.
+  map<string, string> shapes = 3;
+
+  // trip_id -> shape_id. The GTFS-R realtime trip_id is the lookup key.
+  map<string, string> trip_index = 4;
+}

--- a/src/test/kotlin/app/krail/gtfs/track/TrackDatasetBuilderTest.kt
+++ b/src/test/kotlin/app/krail/gtfs/track/TrackDatasetBuilderTest.kt
@@ -1,0 +1,101 @@
+package app.krail.gtfs.track
+
+import app.krail.kgtfs.track.Polyline
+import app.krail.kgtfs.track.buildManifest
+import app.krail.kgtfs.track.buildShapesDataset
+import app.krail.kgtfs.track.buildTrackStops
+import kotlin.math.abs
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class TrackDatasetBuilderTest {
+
+    @Test
+    fun `polyline encoding matches the canonical Google reference vector`() {
+        val points = listOf(
+            Polyline.Point(38.5, -120.2),
+            Polyline.Point(40.7, -120.95),
+            Polyline.Point(43.252, -126.453),
+        )
+        assertEquals("_p~iF~ps|U_ulLnnqC_mqNvxq`@", Polyline.encode(points))
+    }
+
+    @Test
+    fun `polyline round-trips Sydney coordinates within precision 5`() {
+        val points = listOf(
+            Polyline.Point(-33.8688, 151.2093),
+            Polyline.Point(-33.8675, 151.2070),
+            Polyline.Point(-33.9200, 151.0000),
+        )
+        val decoded = Polyline.decode(Polyline.encode(points))
+        assertEquals(points.size, decoded.size)
+        points.zip(decoded).forEach { (a, b) ->
+            assertTrue(abs(a.lat - b.lat) < 1e-5 && abs(a.lon - b.lon) < 1e-5, "$a vs $b")
+        }
+    }
+
+    @Test
+    fun `directory keeps platforms AND stations with raw ids and parent links`() {
+        val stops = buildTrackStops(
+            listOf(
+                mapOf(
+                    "stop_id" to "200060", "stop_name" to "Central Station",
+                    "stop_lat" to "-33.8832", "stop_lon" to "151.2065",
+                    "location_type" to "1", "parent_station" to "",
+                ),
+                mapOf(
+                    "stop_id" to "2000336", "stop_name" to "Central Station Platform 16",
+                    "stop_lat" to "-33.8842", "stop_lon" to "151.2062",
+                    "location_type" to "0", "parent_station" to "200060",
+                ),
+                mapOf(
+                    "stop_id" to "X1", "stop_name" to "Station Entrance",
+                    "stop_lat" to "-33.88", "stop_lon" to "151.20",
+                    "location_type" to "2", "parent_station" to "200060",
+                ),
+            ),
+        )
+        assertEquals(listOf("200060", "2000336"), stops.map { it.stop_id }, "entrances excluded")
+        val platform = stops.single { it.stop_id == "2000336" }
+        assertEquals("Central Station Platform 16", platform.name)
+        assertEquals("200060", platform.parent_id)
+    }
+
+    @Test
+    fun `shapes dataset dedups trips onto shared shapes and prunes orphans`() {
+        val ds = buildShapesDataset(
+            bundleKey = "sydneytrains",
+            version = "20260613",
+            tripRows = listOf(
+                mapOf("trip_id" to "trip-a", "shape_id" to "shape-1"),
+                mapOf("trip_id" to "trip-b", "shape_id" to "shape-1"),
+                mapOf("trip_id" to "trip-c", "shape_id" to "shape-orphan"),
+            ),
+            shapeRows = listOf(
+                mapOf("shape_id" to "shape-1", "shape_pt_lat" to "-33.8688", "shape_pt_lon" to "151.2093", "shape_pt_sequence" to "2"),
+                mapOf("shape_id" to "shape-1", "shape_pt_lat" to "-33.8675", "shape_pt_lon" to "151.2070", "shape_pt_sequence" to "1"),
+                mapOf("shape_id" to "shape-unused", "shape_pt_lat" to "-30.0", "shape_pt_lon" to "150.0", "shape_pt_sequence" to "1"),
+            ),
+        )
+        assertEquals(setOf("trip-a", "trip-b"), ds.trip_index.keys, "trip with missing shape dropped")
+        assertEquals(setOf("shape-1"), ds.shapes.keys, "unused shape dropped")
+        val decoded = Polyline.decode(ds.shapes["shape-1"]!!)
+        assertTrue(abs(decoded.first().lat - -33.8675) < 1e-5, "points ordered by shape_pt_sequence")
+        assertEquals("sydneytrains", ds.feed)
+    }
+
+    @Test
+    fun `manifest carries url, sha256 and size per artifact`() {
+        val manifest = buildManifest(
+            version = "20260613",
+            generatedAt = "2026-06-13T00:00:00Z",
+            releaseUrlBase = "https://github.com/x/y/releases/download/track-latest",
+            artifacts = listOf("track_stops.pb" to byteArrayOf(1, 2, 3)),
+        )
+        assertTrue("\"version\":\"20260613\"" in manifest)
+        assertTrue("\"url\":\"https://github.com/x/y/releases/download/track-latest/track_stops.pb\"" in manifest)
+        assertTrue("\"size_bytes\":3" in manifest)
+        assertTrue("\"sha256\":\"" in manifest)
+    }
+}


### PR DESCRIPTION
## What

Standalone weekly pipeline building the datasets KRAIL-BFF live trip tracking consumes. **Additive — the existing stops/routes pipeline (ci.yml, Main.kt) is untouched.**

- **`track_stops.pb`** — platform-level stop directory merged across modes (raw GTFS ids incl. `location_type` 0 platforms + `parent_station` links). Names the train platform ids the app's search dataset lacks (e.g. \"Central Station Platform 16\").
- **`shapes_<bundle>.pb`** per mode — `shape_id → encoded polyline` (precision 5) + `trip_id → shape_id` index, deduped. Bundles: sydneytrains, nswtrains, metro, lightrail, sydney ferries. Buses excluded by design.
- **`track_manifest.json`** — version + per-artifact url/sha256/size.

## How it ships

New workflow `track-dataset.yml` (weekly cron Sun 16:00 UTC + manual dispatch) publishes everything to the rolling **`track-latest`** GitHub Release. Nothing committed to git — machine-derived binaries. The BFF points `TRACK_DATASET_MANIFEST_URL` at the release, re-checks ~6-hourly, sha256-verifies, hot-swaps in memory. No PRs needed to keep the BFF current; a failed run only degrades tracking gracefully (straight-line maps, search-dataset names).

## Wire contract

`TrackDataset.proto` field numbers/types must stay identical to the BFF decoder (`KRAIL-BFF/server/src/main/proto/nsw/track-dataset.proto`). Documented in both files + docs/TrackDatasets.md.

## Verified

- Unit tests (polyline reference vector, directory filtering, shape dedup/orphan pruning, manifest shape)
- Full live run: 2227 stops + 569 shapes across 5 modes from real NSW data (~9 MB total)
- Cross-repo: a local BFF decoded these exact artifacts and returned `GTFS_SHAPES` geometry with fully named platform stops for a live train

Uses a lenient CSV parser — NSW ships malformed quoting in some bundles (nswtrains stops.txt) that strict parsers reject.

🤖 Generated with [Claude Code](https://claude.com/claude-code)